### PR TITLE
Update shard.yml

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,15 +1,10 @@
 name: citrine-i18n
 
-version: 0.4.0
+version: 0.4.1
 
 authors:
   - Amber Team and Contributors <amberframework.org>
 
-crystal: 0.30.0
+crystal: ">= 0.30.0, < 2.0.0"
 
 license: MIT
-
-dependencies:
-  i18n:
-    github: TechMagister/i18n.cr
-    version: 0.3.1


### PR DESCRIPTION
Decouple citrine from any one i18n implementation. As long as the i18n implementation included in shard.yml maintains the same interface, then all should be well